### PR TITLE
README: remove duplication

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -156,14 +156,6 @@ option to the command line:
 baryonyx-0.5 -o file.lp
 ....
 
-To run baryonyx into the heuristic model (i trying to valid all
-constraints and optimize the solution), add a `-o` or `--optimize`
-option to the command line:
-
-....
-baryonyx-0.5 -o file.lp
-....
-
 The Baryonyx solver have many parameters. Some parameters are global,
 some specific for the optimization algorithms.
 


### PR DESCRIPTION
The following parts in `README.adoc` were duplicated. So I removed one of them.

```
To run baryonyx into the heuristic model (i trying to valid all
constraints and optimize the solution), add a `-o` or `--optimize`
option to the command line:
....
baryonyx-0.5 -o file.lp
....
```
